### PR TITLE
Specify relative peer dependencies for @angular/forms

### DIFF
--- a/projects/datorama/akita-ng-forms-manager/package.json
+++ b/projects/datorama/akita-ng-forms-manager/package.json
@@ -4,7 +4,7 @@
   "peerDependencies": {
     "@angular/common": "^7.0.0",
     "@angular/core": "^7.0.0",
-    "@angular/forms": "7.0.0",
+    "@angular/forms": "^7.0.0",
     "@datorama/akita": "^1.22.1"
   }
 }


### PR DESCRIPTION
To avoid warning error when npm install. Angualr forms is already : 7.1.4. 
By specifying fixe version, we have an unwanted warm version.