### PR TITLE
fix when passing non FormArray array as control value

### DIFF
--- a/projects/datorama/akita-ng-forms-manager/src/lib/forms-manager.ts
+++ b/projects/datorama/akita-ng-forms-manager/src/lib/forms-manager.ts
@@ -203,7 +203,7 @@ export class AkitaNgFormsManager<FormsState = any> {
     } else {
       Object.keys(formValue).forEach(controlName => {
         const value = formValue[controlName];
-        if (Array.isArray(value)) {
+        if (Array.isArray(value) && value instanceof FormArray) {
           const current = control.get(controlName) as FormArray;
           const fc = arrControlFactory[controlName];
           if (!fc) {


### PR DESCRIPTION
Below throws an error because it assumes you are passing a FormArray.
```
this.config = new FormGroup({
    skills: [1, 2, 3]
})
```